### PR TITLE
Ajuste de rota pesquisa por id

### DIFF
--- a/APICatalogo.NET5/Controllers/ProdutosController.cs
+++ b/APICatalogo.NET5/Controllers/ProdutosController.cs
@@ -35,7 +35,7 @@ namespace APICatalogo.NET5.Controllers
             }
         }
 
-        [HttpGet("{id}", Name ="ObtenhaProdutos")]
+        [HttpGet("{id}Produtos")]
         public ActionResult<Produto> GetProdutosById(int id) 
         {
             try


### PR DESCRIPTION
As rotas não podem ter o mesmo endereço da api anterior